### PR TITLE
Add bounds() function to toggle layout bounds on/off

### DIFF
--- a/android_functions.sh
+++ b/android_functions.sh
@@ -35,3 +35,12 @@ function run_scrcpy {
     [ ! -z "$sn" ] && scrcpy -s $sn
   done < <(adb devices | sed '1d' | grep -v "emulator")
 }
+
+# Enables/disables layout bounds
+function bounds() {
+  if [[ $1 = 'on' ]]; then
+    adb shell setprop debug.layout true; adb shell service call activity 1599295570 > /dev/null
+  else
+    adb shell setprop debug.layout false; adb shell service call activity 1599295570 > /dev/null
+  fi
+}


### PR DESCRIPTION
Allows to toggle layout bounds on or off with

```
λ bounds [on|off]
```

Feel free to discard if you don't want that! :) 